### PR TITLE
No period at the end of a title

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
 * Correction d'une petite faute de typo dans l'aide de l'outil en ligne de commande et reformulation.
 * Correctif sur les exemples du README et les fichiers exemples en HTML et Markdown.
 * Ajout de la correction des doubles, triples, quadruples, nuples points d'exclamation et d'interrogation (#17).
+* Ajout d'une règle : un titre ne doit pas se terminer par un point (#19).
 * Ajout de gabarits pour la création de rapports de bogue ou de demandes de fonctionnalités (#18).
 * Ajout d'un gabarit pour la création de "pull-requests".
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Chaque règle peut être désactivée via le paramétrage de la fonction ``typog
 * ``fix_apostrophes`` : transformer les apostrophes "dactylographiques" en apostrophes "typographiques",
 * ``fix_nbsp`` : les espaces insécables ne seront pas converties en entités HTML, mais laissées telles quelles.
 * ``fix_nuples`` : appliquer les règles sur les points d'exclamation et d'interrogation multiples.
+* ``fix_title_points`` : appliquer la règle interdisant les points à la fin d'un titre.
 
 ## Outil en ligne de commande
 
@@ -113,7 +114,8 @@ Par défaut, tous les paramètres de la fonction ``typographeur()`` sont activé
 * ``--skip-double-quote``,
 * ``--skip-apostrophes``,
 * ``--skip-nbsp``,
-* ``--skip-nuples``.
+* ``--skip-nuples``,
+* ``--skip-title-points``.
 
 Toutes les options disponibles sont visibles via :
 

--- a/tests/examples/expected.html
+++ b/tests/examples/expected.html
@@ -18,6 +18,7 @@
             <li>Une citation [..] incomplète</li>
             <li>Deux points d’interrogation&#8239;??? ou deux points d’exclamation&#8239;!!!</li>
         </ul>
+        <h2>Un titre ne se termine jamais par un point</h2>
     </article>
     <article>
         <h1>Et si le texte est déjà correct…</h1>

--- a/tests/examples/input.html
+++ b/tests/examples/input.html
@@ -18,6 +18,7 @@
             <li>Une citation [......] incomplète</li>
             <li>Deux points d'interrogation ?? ou deux points d'exclamation !!</li>
         </ul>
+        <h2>Un titre ne se termine jamais par un point.</h2>
     </article>
     <article>
         <h1>Et si le texte est déjà correct…</h1>

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -86,3 +86,18 @@ def test_nbsp(input, expected):
 def test_nuples(input, expected):
     output = typographeur(input, fix_nuples=False)
     assert output == expected
+
+
+@pytest.mark.parametrize("input,expected", [
+    ("<h1>Titre</h1>", "<h1>Titre</h1>"),
+    ("<h1>Titre.</h1>", "<h1>Titre.</h1>"),
+    ("<h2>Titre.</h2>", "<h2>Titre.</h2>"),
+    ("<h3>Titre.</h3>", "<h3>Titre.</h3>"),
+    ("<h4>Titre.</h4>", "<h4>Titre.</h4>"),
+    ("<h5>Titre.</h5>", "<h5>Titre.</h5>"),
+    ("<h6>Titre.</h6>", "<h6>Titre.</h6>"),
+    ("<title>Titre.</title>", "<title>Titre.</title>"),
+])
+def test_title_points(input, expected):
+    output = typographeur(input, fix_title_points=False)
+    assert output == expected

--- a/tests/test_points.py
+++ b/tests/test_points.py
@@ -25,3 +25,28 @@ def test_points(input, expected):
 def test_dual_points(input, expected):
     output = typographeur(input)
     assert output == expected
+
+
+@pytest.mark.parametrize("input,expected", [
+    ("<h1>Titre</h1>", "<h1>Titre</h1>"),
+    ("<h1>Titre.</h1>", "<h1>Titre</h1>"),
+    ("<h2>Titre.</h2>", "<h2>Titre</h2>"),
+    ("<h3>Titre.</h3>", "<h3>Titre</h3>"),
+    ("<h4>Titre.</h4>", "<h4>Titre</h4>"),
+    ("<h5>Titre.</h5>", "<h5>Titre</h5>"),
+    ("<h6>Titre.</h6>", "<h6>Titre</h6>"),
+])
+def test_heading_points(input, expected):
+    output = typographeur(input)
+    assert output == expected
+
+
+@pytest.mark.parametrize("input,expected", [
+    ("<title>Titre.</title>", "<title>Titre</title>"),
+    ("<title>Titre.\n</title>", "<title>Titre</title>"),
+    ("<title>Titre.\nAutre titre.</title>",
+     "<title>Titre.\nAutre titre</title>"),
+])
+def test_title_points(input, expected):
+    output = typographeur(input)
+    assert output == expected


### PR DESCRIPTION
closes or refs #xxx

### Checklist

- [x] Adding unittests.
- [x] Editing the ``input.html`` and ``expected.html`` files to add examples in the *"Les exemples"* and the *"Et si le texte est déjà correct…"* sections.
- [x] Add the ``fix_<feature>`` flag
  - [x] Cover the ``True/False`` cases,
  - [x] Add the param help text in the function docstring,
  - [x] Add the ``skip_feature`` argument for the CLI tool,
  - [x] Test the parameters,
- [x] Changelog entry.
